### PR TITLE
Port over !!revemb trick from K9

### DIFF
--- a/tags/fun/revemb.ytag
+++ b/tags/fun/revemb.ytag
@@ -1,0 +1,5 @@
+type: text
+
+---
+
+remove {{0}}. embrace {{1}}. <:tiny_potato:552977803633623040>


### PR DESCRIPTION
In the migration of K9's tricks, I noticed that !!revemb, the command that prints "remove x. embrace y.", was not ported. While obviously this command is not that serious, I feel that it has value as a command that can inject humor into discussion where appropriate.