### PR TITLE
Add guides for refactoring identifiers

### DIFF
--- a/tags/guide/identifier.ytag
+++ b/tags/guide/identifier.ytag
@@ -1,0 +1,2 @@
+type: alias
+target: guide/identifiers

--- a/tags/guide/identifiers.ytag
+++ b/tags/guide/identifiers.ytag
@@ -1,0 +1,22 @@
+type: text
+
+---
+
+**How to create `Identifier`s *neatly***
+
+In your main mod class or a helper class:
+(in this example, `YourMod`)
+```java
+public static final String MODID = "yourmod";
+
+// ...
+
+public static Identifier id(String path) {
+    return new Identifier(YourMod.MODID, path);
+}
+```
+To use it:
+```java
+YourMod.id("myitem")                    // yourmod:myitem
+YourMod.id("textures/gui/mygui.png")    // yourmod:textures/gui/mygui.png
+```


### PR DESCRIPTION
Now you can create `Identifier`s without using that clunky `new Identifier(...)` syntax! (tbh it's kind of an eyesore to see them multiple times in a single snippet) :tiny_potato: