### PR TITLE
Add trick for community discords link on wiki

### DIFF
--- a/tags/discord/communitydiscords.ytag
+++ b/tags/discord/communitydiscords.ytag
@@ -1,0 +1,6 @@
+type: text
+
+---
+
+A list of fabric community discord servers can be found on the wiki:
+LINK HERE

--- a/tags/discord/communitydiscords.ytag
+++ b/tags/discord/communitydiscords.ytag
@@ -3,4 +3,4 @@ type: text
 ---
 
 A list of fabric community discord servers can be found on the wiki:
-LINK HERE
+https://fabricmc.net/wiki/community_discords


### PR DESCRIPTION
Waiting for the wiki page to pop up to fill in the url