### PR TITLE
Add Matrix tag

### DIFF
--- a/tags/link/matrix.ytag
+++ b/tags/link/matrix.ytag
@@ -1,0 +1,4 @@
+**Matrix/Element and Fabric**
+At the moment, there is no official Matrix room for Fabric.
+However, an *unofficial* one can be found at https://matrix.to/#/#fabricmc-unofficial:matrix.org
+The rules can be found on the community page, at https://matrix.to/#/+fabricmc:matrix.org


### PR DESCRIPTION
Some people prefer to use Matrix, and so in the same spirit as the community discord page, etc. I thought it would be good to have a link to the unofficial Matrix room.