### PR TITLE
Update ssmods.ytag

### DIFF
--- a/tags/link/ssmods.ytag
+++ b/tags/link/ssmods.ytag
@@ -2,5 +2,5 @@ type: text
 
 ---
 
-Useful Fabric server side mods gist:
-<https://gist.github.com/comp500/12417ee3685f6204362e933c9bcde603>
+Fabric Server-side Mods:
+<https://github.com/comp500/fabric-serverside-mods>


### PR DESCRIPTION
updated link to point to the current gh repo that replaced the gist