### PR TITLE
Update logs.ytag

### DIFF
--- a/tags/guide/logs.ytag
+++ b/tags/guide/logs.ytag
@@ -2,23 +2,11 @@ type: embed
 
 colour: blurple
 embed:
-    title: Sharing Logs
+    title: How to post your logs to get help
 
 ---
 
 When requesting support for a crash or other error, you should provide error logs - this will give us the information we'll need to help you.
 
-**How to post your logs to get help:**
-
 **»** [Windows/Linux](https://fabricmc.net/wiki/player:tutorials:logs_ml:windows)
 **»** [MacOS](https://fabricmc.net/wiki/player:tutorials:logs_ml:mac)
-
-When posting logs, it's best to use a paste site - this means that people can read your logs without having to first download them as a file, which is particularly annoying for mobile users.
-
-**Paste sites and their limits:**
-
-**»** [GitHub Gist](https://gist.github.com/): 100 MiB / Requires membership
-**»** [Paste.gg](https://paste.gg/): 15 MiB / Optional membership
-**»** [Paste.ee](https://paste.ee/): 1 MiB / Optional membership (raises limit to 6 MiB)
-**»** [Pastebin.com](https://pastebin.com/): 512 KiB / Optional membership
-**»** [Hastebin.com](https://hastebin.com/): 400 KiB / Anonymous


### PR DESCRIPTION
Make it way shorter, since most of the current info is actually on the linked wiki tutorials. avoids the logs wall of text in #player-support