### PR TITLE
Add a new link to events.ytag 

### DIFF
--- a/tags/link/events.ytag
+++ b/tags/link/events.ytag
@@ -2,4 +2,4 @@ type: text
 
 ---
 
-A list of Fabric API events/callbacks can be found at https://fabricmc.net/wiki/tutorial:callbacks.
+A list of Fabric API events/callbacks can be found at https://fabricmc.net/wiki/tutorial:callbacks, for a more complete and up to date list, refer to https://jamalam.gitbook.io/fabric-tutorials/events/list-of-fabric-api-events.


### PR DESCRIPTION
I created a page with all Fabric API events I could find at https://jamalam.gitbook.io/fabric-tutorials/events/list-of-fabric-api-events so I thought it would be ideal to have it on this tag, it's a lot more complete than the one on the Fabric Wiki. It's not on the official wiki because I find it to look dated and wanted to use a better platform with more formatting control etc.

thanks :)