### PR TITLE
update jdk.ytag

### DIFF
--- a/tags/link/jdk.ytag
+++ b/tags/link/jdk.ytag
@@ -2,4 +2,7 @@ type: text
 
 ---
 
-https://adoptium.net/
+# Adoptium (AdoptOpenJDK)
+
+[Java 16](https://adoptium.net/archive.html?variant=openjdk16&jvmVariant=hotspot) for Minecraft 1.17 and later
+[Java 8](https://adoptium.net/archive.html?variant=openjdk8&jvmVariant=hotspot) for Minecraft 1.16 and earlier


### PR DESCRIPTION
With the release of Java 17 as LTS, Adoptium have removed the Java 16 option from their releases page, and moved it to the archive.

This PR fixes that, and points users to the right Java version for their respective MC version.