### PR TITLE
Begin removal of 3rd party links no longer specific to Fabric

### DIFF
--- a/tags/discord/legacyfabric.ytag
+++ b/tags/discord/legacyfabric.ytag
@@ -1,0 +1,5 @@
+type: text
+
+---
+
+https://discord.gg/emgF7bp

--- a/tags/discord/rewovenmc.ytag
+++ b/tags/discord/rewovenmc.ytag
@@ -1,5 +1,0 @@
-type: text
-        
----
-
-https://discord.gg/K9U4PfmFfp

--- a/tags/faq/optifine.ytag
+++ b/tags/faq/optifine.ytag
@@ -5,7 +5,7 @@ type: text
 OptiFine doesn't support Fabric natively.
 
 If you are willing to try alternatives, please look at this list:
-<https://github.com/FeltMC/optifine_alternatives>
+<https://fabricmc.net/wiki/optifine-alternatives>
 
 If you need shaders but not OptiFine, Iris is the mod for you, find more about it here:
 <https://irisshaders.net/download.html>

--- a/tags/faq/optifine.ytag
+++ b/tags/faq/optifine.ytag
@@ -5,7 +5,7 @@ type: text
 OptiFine doesn't support Fabric natively.
 
 If you are willing to try alternatives, please look at this list:
-<https://github.com/PseudoDistant/optifine_alternatives>
+<https://github.com/FeltMC/optifine_alternatives>
 
 If you need shaders but not OptiFine, Iris is the mod for you, find more about it here:
 <https://irisshaders.net/download.html>

--- a/tags/faq/optifine.ytag
+++ b/tags/faq/optifine.ytag
@@ -5,7 +5,7 @@ type: text
 OptiFine doesn't support Fabric natively.
 
 If you are willing to try alternatives, please look at this list:
-<https://lambdaurora.dev/optifine_alternatives>
+<https://github.com/PseudoDistant/optifine_alternatives>
 
 If you need shaders but not OptiFine, Iris is the mod for you, find more about it here:
 <https://irisshaders.net/download.html>

--- a/tags/guide/server.ytag
+++ b/tags/guide/server.ytag
@@ -8,4 +8,4 @@ embed:
 **»** [Installing a Minecraft/Fabric Server](https://fabricmc.net/wiki/tutorial:installing_minecraft_fabric_server)
 **»** [Installing a Fabric Server without a GUI](https://fabricmc.net/wiki/player:tutorials:install_server)
 **»** [1.17 Server requires Java 16](https://fabricmc.net/wiki/player:tutorials:mc-1.17-server)
-**»** [A list of Fabric Server-side Mods](https://github.com/PseudoDistant/fabric-serverside-mods)
+**»** [A list of Fabric Server-side Mods](https://fabricmc.net/wiki/serverside-mods)

--- a/tags/guide/server.ytag
+++ b/tags/guide/server.ytag
@@ -8,4 +8,4 @@ embed:
 **»** [Installing a Minecraft/Fabric Server](https://fabricmc.net/wiki/tutorial:installing_minecraft_fabric_server)
 **»** [Installing a Fabric Server without a GUI](https://fabricmc.net/wiki/player:tutorials:install_server)
 **»** [1.17 Server requires Java 16](https://fabricmc.net/wiki/player:tutorials:mc-1.17-server)
-**»** [A list of Fabric Server-side Mods](https://github.com/comp500/fabric-serverside-mods)
+**»** [A list of Fabric Server-side Mods](https://github.com/PseudoDistant/fabric-serverside-mods)

--- a/tags/link/ssmods.ytag
+++ b/tags/link/ssmods.ytag
@@ -3,4 +3,4 @@ type: text
 ---
 
 Fabric Server-side Mods:
-<https://github.com/PseudoDistant/fabric-serverside-mods>
+<https://github.com/FeltMC/fabric-serverside-mods>

--- a/tags/link/ssmods.ytag
+++ b/tags/link/ssmods.ytag
@@ -3,4 +3,4 @@ type: text
 ---
 
 Fabric Server-side Mods:
-<https://github.com/comp500/fabric-serverside-mods>
+<https://github.com/PseudoDistant/fabric-serverside-mods>

--- a/tags/link/ssmods.ytag
+++ b/tags/link/ssmods.ytag
@@ -3,4 +3,4 @@ type: text
 ---
 
 Fabric Server-side Mods:
-<https://github.com/FeltMC/fabric-serverside-mods>
+<https://fabricmc.net/wiki/serverside-mods>


### PR DESCRIPTION
I have created my own forks of 

https://github.com/LambdAurora/optifine_alternatives

https://github.com/comp500/quilt-serverside-mods

and I replaced the links to these with my own.

(Also I restored the Legacy Fabric invite link.)