### PR TITLE
Added a tag explaining binary search

### DIFF
--- a/tags/guide/binarysearch.ytag
+++ b/tags/guide/binarysearch.ytag
@@ -1,0 +1,11 @@
+type: text
+
+---
+
+A binary search can be used to quickly find a specific mod causing trouble, which can be especially useful when logs don't give a conclusive answer to your issue.
+
+Start by removing or disabling half of your mods, then test if the problem still occurs. If it does, remove half of the remaining mods and test again. If it doesn't, add back half of the mods you just removed.
+
+Keep in mind you don't have to stick strictly to halves each time, and may have to enable some library mods like Fabric API out of order.
+
+By repeating this on an increasingly smaller set of mods, you'll find the problematic mod within a few iterations.


### PR DESCRIPTION
A tag for Fabric Bot briefly explaining how to use a binary search to find problematic mods in a modded installation.