### PR TITLE
Modify the paste tag to include mclo.gs

### DIFF
--- a/tags/guide/paste.ytag
+++ b/tags/guide/paste.ytag
@@ -13,6 +13,7 @@ Dumping your code/log in a code block or a message can make it difficult for oth
 
 **»** [GitHub Gist](https://gist.github.com/): 100 MiB / Requires membership
 **»** [Paste.gg](https://paste.gg/): 15 MiB / Optional membership
+**»** [Mclo.gs](https://mclo.gs/): 10 MiB / Anonymous (designed specifically for Minecraft logs)
 **»** [Paste.ee](https://paste.ee/): 1 MiB / Optional membership (raises limit to 6 MiB)
 **»** [Pastebin.com](https://pastebin.com/): 512 KiB / Optional membership
 **»** [Hastebin.com](https://hastebin.com/): 400 KiB / Anonymous


### PR DESCRIPTION
https://mclo.gs/ is a great paste site designed specifically for Minecraft logs, it provides syntax highlighting and automatic analysis of common issues. I think it'd be good to have it listed in the `paste` tag, as it could help with diagnosing issues from players.