### PR TITLE
Mention the use of paste sites in the logs tag

### DIFF
--- a/tags/guide/logs.ytag
+++ b/tags/guide/logs.ytag
@@ -6,7 +6,7 @@ embed:
 
 ---
 
-When requesting support for a crash or other error, you should provide error logs - this will give us the information we'll need to help you.
+When requesting support for a crash or other error, you should provide error logs - this will give us the information we'll need to help you. Please make sure to upload these logs to a paste site instead of uploading the file directly, see the `paste` tag for a list of sites you can use.
 
 **»** [Windows/Linux](https://fabricmc.net/wiki/player:tutorials:logs_ml:windows)
 **»** [MacOS](https://fabricmc.net/wiki/player:tutorials:logs_ml:mac)


### PR DESCRIPTION
This PR adds a request to use a paste site for log uploading to the `logs` tag. I think this would greatly help with analysing large logs, as players tend to always upload logs directly as files if the `paste` tag isnt mentioned, and big logs can't be easily viewed within Discord.