### PR TITLE
clarify the paste tag reference in `logs.ytag`

### DIFF
--- a/tags/guide/logs.ytag
+++ b/tags/guide/logs.ytag
@@ -6,7 +6,7 @@ embed:
 
 ---
 
-When requesting support for a crash or other error, you should provide error logs - this will give us the information we'll need to help you. Please make sure to upload these logs to a paste site instead of uploading the file directly, see the `paste` tag for a list of sites you can use.
+When requesting support for a crash or other error, you should provide error logs - this will give us the information we'll need to help you. Please make sure to upload these logs to a paste site instead of uploading the file directly. Type `!!paste` for a list of sites you can use.
 
 **»** [Windows/Linux](https://fabricmc.net/wiki/player:tutorials:logs_ml:windows)
 **»** [MacOS](https://fabricmc.net/wiki/player:tutorials:logs_ml:mac)


### PR DESCRIPTION
visitors to the guild (who are most likely to be the audience of this tag) might not realize what "the paste tag" refers to

old: 
```
...instead of uploading the file directly, see the `paste` tag for a list of sites you can use.
```
new: 
```
...instead of uploading the file directly. Type `!!paste` for a list of sites you can use.
```