### PR TITLE
Tell users what not to do in the logs tag

### DIFF
--- a/tags/guide/logs.ytag
+++ b/tags/guide/logs.ytag
@@ -6,7 +6,7 @@ embed:
 
 ---
 
-When requesting support for a crash or other error, you should provide error logs - this will give us the information we'll need to help you. Please make sure to upload these logs to a paste site instead of uploading the file directly, see the `paste` tag for a list of sites you can use.
+When requesting support for a crash or other error, you should provide error logs - this will give us the information we'll need to help you. Please make sure to upload these logs to a paste site instead of uploading the file directly, see the `paste` tag for a list of sites you can use. It is especially important if you have a log too large for Discord. Do not copy and paste, screenshot, or significantly alter your logs.
 
 **»** [Windows/Linux](https://fabricmc.net/wiki/player:tutorials:logs_ml:windows)
 **»** [MacOS](https://fabricmc.net/wiki/player:tutorials:logs_ml:mac)


### PR DESCRIPTION
Too many people don't click on the link as is. Hopefully this'll reduce some issues. This also adds one reason why we ask users to upload their logs to a paste site. Feel free to edit!!