### PR TITLE
Use CaffeineMC recommended mod distribution website in jellysquid tag

### DIFF
--- a/tags/faq/jellysquid.jar.ytag
+++ b/tags/faq/jellysquid.jar.ytag
@@ -4,6 +4,6 @@ type: text
 
 The speedrunning community uses 'JellySquid' to refer to three performance mods that they authored: Sodium, Lithium, and Phosphor.
 
-**»** Sodium: <https://www.curseforge.com/minecraft/mc-mods/sodium>
-**»** Lithium: <https://www.curseforge.com/minecraft/mc-mods/lithium>
-**»** Phosphor: <https://www.curseforge.com/minecraft/mc-mods/phosphor>
+**»** Sodium: <https://modrinth.com/mod/sodium>
+**»** Lithium: <https://modrinth.com/mod/lithium>
+**»** Phosphor: <https://modrinth.com/mod/phosphor>


### PR DESCRIPTION
CaffeineMC has stated that their mods will receive updates quicker on Modrinth and may also start publishing their exclusively for future releases.