### PR TITLE
Remove CurseForge link from modmenu tag

### DIFF
--- a/tags/guide/modmenu.ytag
+++ b/tags/guide/modmenu.ytag
@@ -3,6 +3,6 @@ type: text
 ---
 
 Fabric doesn't come with a mod menu built-in. There's a mod called Mod Menu that adds it. 
-You can download it from [CurseForge](https://www.curseforge.com/minecraft/mc-mods/modmenu) or [Modrinth](https://modrinth.com/mod/modmenu).
+You can download it from [Modrinth](https://modrinth.com/mod/modmenu).
 Some mods integrate with Mod Menu and add in-game configuration screens.
 Click on the "Mods" button and select the mod you want to configure; if the mod integrates with Mod Menu, you'll see a "Settings" button on the top-right.


### PR DESCRIPTION
The CurseForge page is discontinued, as stated by Prospector in [this discord message](https://discord.com/channels/507304429255393322/566418023372816394/1099033440982142976)