### PR TITLE
Clarify what the links in logs.ytag are for.

### DIFF
--- a/tags/guide/logs.ytag
+++ b/tags/guide/logs.ytag
@@ -12,5 +12,6 @@ Please make sure to upload these logs to a paste site instead of uploading the f
 
 Do not copy and paste, screenshot, or significantly alter your logs.
 
+Where to find your logs:
 **»** [Windows/Linux](https://fabricmc.net/wiki/player:tutorials:logs_ml:windows)
 **»** [macOS](https://fabricmc.net/wiki/player:tutorials:logs_ml:mac)


### PR DESCRIPTION
The links at the bottom of logs.ytag are useful for finding where your logs are, however, this isn't explicitly stated and are thus sometimes overlooked. I feel that added clarity would be helpful.