### PR TITLE
Update iris shaders website URL

### DIFF
--- a/tags/faq/optifine.ytag
+++ b/tags/faq/optifine.ytag
@@ -8,7 +8,7 @@ If you are willing to try alternatives, please look at this list:
 <https://fabricmc.net/wiki/optifine-alternatives>
 
 If you need shaders but not OptiFine, Iris is the mod for you. Find more about it here:
-<https://irisshaders.net/download.html>
+<https://irisshaders.dev/download>
 
 If, however, you really *really* want OptiFine, please know first OptiFine can cause heavy incompatibilities that are, in some cases, not easy to fix.
 


### PR DESCRIPTION
[irisshaders.net](irisshaders.net) expired and the dev team is yet to establish access. They will be using [irisshaders.dev](irisshaders.dev) going forward. 

https://discord.com/channels/774352792659820594/817181278931517453/1118557285300580465

![image](https://github.com/FabricMC/community/assets/121529979/fc1deb83-1176-46de-b3fa-4669760eb82d)
