### PR TITLE
fix wording in `runclient` tag's description

### DIFF
--- a/tags/guide/runclient.ytag
+++ b/tags/guide/runclient.ytag
@@ -10,6 +10,6 @@ embed:
 
 You may be inclined to use the `runClient` Gradle task. `runClient` is provided for IDEs that do not support Run Configurations.
 If you're using a modern IDE like IntelliJ IDEA, VSCode or Eclipse, Fabric Loom will generate Run Configurations for you.
-Run Configurations integrate better IDE's capabilities allowing better debugging and error detection.
+Run Configurations integrate with IDE's capabilities allowing better debugging and error detection.
 
 Read more: [Setting Up a Mod Development Environment](https://fabricmc.net/wiki/tutorial:setup)


### PR DESCRIPTION
Noticed a minor error in the wording.