### PR TITLE
September 2023 tag updates

### DIFF
--- a/tags/cheatsheet/nbttypes.ytag
+++ b/tags/cheatsheet/nbttypes.ytag
@@ -17,4 +17,4 @@ COMPOUND -> 10
 INT_ARRAY -> 11
 LONG_ARRAY -> 12
 ```
-https://maven.fabricmc.net/docs/yarn-1.19.3+build.5/net/minecraft/nbt/package-summary.html
+https://maven.fabricmc.net/docs/yarn-1.20.2+build.1/net/minecraft/nbt/package-summary.html

--- a/tags/faq/contactmod.ytag
+++ b/tags/faq/contactmod.ytag
@@ -2,10 +2,9 @@ type: text
 
 ---
 
-If there is an urgent matter and you need to contact a moderator, there are several options:
+If you want to report inappropriate contents or otherwise need to contact a moderator:
 
 1. Mention the <@&765938438989152266> role.
-2. Send a private message directly to <@748446881574551672> to open a ModMail thread.
-3. If the problem concerns a member of staff, send a private message directly to a different member of staff.
+2. If the problem concerns a member of staff, send a private message directly to a different member of staff.
 
-Please remember that all moderators are volunteers, and would prefer you don't use these options to contact them about trivial matters or support requests.
+Please remember that all moderators are volunteers, and would prefer you don't use these options to contact them about bugs, questions, or support requests.

--- a/tags/guide/clientcommands.ytag
+++ b/tags/guide/clientcommands.ytag
@@ -2,13 +2,13 @@ type: text
 
 ---
 
-Fabric API now has a client commands functionality: https://maven.fabricmc.net/docs/fabric-api-0.70.0+1.19.3/net/fabricmc/fabric/api/client/command/v2/ClientCommandManager.html
+Fabric API now has a client commands functionality: https://maven.fabricmc.net/docs/fabric-api-0.89.2+1.20.2/net/fabricmc/fabric/api/client/command/v2/ClientCommandRegistrationCallback.html
 
 ```java
 ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> {
     dispatcher.register(
         ClientCommandManager.literal("hello").executes(context -> {
-            context.getSource().sendFeedback(Text.literal("Hello, world!"));
+            context.getSource().sendFeedback(() -> Text.literal("Hello, world!"));
             return 0;
         })
     );

--- a/tags/guide/mojmap-loom.ytag
+++ b/tags/guide/mojmap-loom.ytag
@@ -2,7 +2,7 @@ type: text
 
 ---
 
-To use Mojmap in your project, please follow these instructions. **Remember:** As per rule 8, we do not allow mentions of Mojmap names on Discord.
+To use Mojmap in your project, please follow these instructions.
 
 __**Please read and understand the EULA before using!**__
 

--- a/tags/guide/objectinputstream.ytag
+++ b/tags/guide/objectinputstream.ytag
@@ -1,0 +1,2 @@
+type: alias
+target: guide/ois

--- a/tags/guide/ois.ytag
+++ b/tags/guide/ois.ytag
@@ -1,0 +1,10 @@
+type: text
+
+---
+
+**Do not use `ObjectInputStream`** unless you know what you are doing.
+
+`ObjectInputStream` is associated with several vulnerabilities.
+While the impact is benign in many cases, there have been some successful exploits in the past.
+
+Use other serialization methods like JSON or NBT, or serialize each field of a class manually.

--- a/tags/lib/architectury.ytag
+++ b/tags/lib/architectury.ytag
@@ -1,0 +1,9 @@
+type: text
+
+---
+
+Architectury allows building multi-platform (Fabric and Forge) mods.
+
+https://github.com/architectury/architectury-templates
+
+Architectury API, an API mod for Architectury mods: <https://github.com/architectury/architectury-api>

--- a/tags/lib/astralbody.ytag
+++ b/tags/lib/astralbody.ytag
@@ -1,7 +1,0 @@
-type: text
-
----
-
-Custom Astral Body is an api that allows you to change how celestial bodies (sky, moon, stars) are rendered and supports custom rendering of those objects as well.
-
-https://github.com/vampire-studios/Customized-Astral-Body

--- a/tags/lib/banner++.ytag
+++ b/tags/lib/banner++.ytag
@@ -1,7 +1,0 @@
-type: text
-
----
-
-Banner++ is an api that allows mods to register their own banner patterns
-
-https://github.com/kvverti/banner-plus-plus

--- a/tags/lib/clothconfig.ytag
+++ b/tags/lib/clothconfig.ytag
@@ -2,6 +2,7 @@ type: text
 
 ---
 
-Cloth Config is a config screen builder api that allows mods to build their own config screens to provide a user friendly way to access the mod's config
+Cloth Config is a config screen builder api that allows mods to build their own config screens to provide a user friendly way to access the mod's config.
+Note: Cloth Config **should not be used** in future projects; use other config libraries like YACL (`!!yacl`).
 
 https://github.com/shedaniel/cloth-config

--- a/tags/lib/drawer.ytag
+++ b/tags/lib/drawer.ytag
@@ -4,4 +4,4 @@ type: text
 
 A **Kotlin Only** api for automatically serializing and deserializing packet byte bufs and NBT
 
-https://github.com/natanfudge/Fabric-Drawer/
+https://github.com/natanfudge/Kotlinx-Serialization-Minecraft

--- a/tags/lib/erapi.ytag
+++ b/tags/lib/erapi.ytag
@@ -1,7 +1,0 @@
-type: text
-
----
-
-Energy API for the Energon Relics mod.
-
-https://jenkins.thebrokenrail.com/job/EnergonRelics/job/master/JavaDoc

--- a/tags/lib/fiber.ytag
+++ b/tags/lib/fiber.ytag
@@ -1,7 +1,0 @@
-type: text
-
----
-
-Fiber is a FabLabs api for configs using builders and annotations.
-
-https://github.com/FabLabsMC/fiber

--- a/tags/lib/freshcoffee.ytag
+++ b/tags/lib/freshcoffee.ytag
@@ -1,7 +1,0 @@
-type: text
-
----
-
-Fresh Coffee is a library that makes sure that your running the right version of java and can install the correct version if not
-
-https://gitea.thebrokenrail.com/TheBrokenRail/FreshCoffee

--- a/tags/lib/ksm.ytag
+++ b/tags/lib/ksm.ytag
@@ -1,0 +1,2 @@
+type: alias
+target: lib/drawer

--- a/tags/lib/libcbe.ytag
+++ b/tags/lib/libcbe.ytag
@@ -1,7 +1,0 @@
-type: text
-
----
-
-LibCBE is an api that allows mods to register conditional block entities
-
-https://github.com/BoogieMonster1O1/libcbe

--- a/tags/lib/libschem.ytag
+++ b/tags/lib/libschem.ytag
@@ -1,7 +1,0 @@
-type: text
-
----
-
-A schematic placer and parser that supports the sponge v2 format
-
-https://github.com/BoogieMonster1O1/LibSchem

--- a/tags/lib/midnightlib.ytag
+++ b/tags/lib/midnightlib.ytag
@@ -1,0 +1,7 @@
+type: text
+
+---
+
+MidnightLib is a configuration library.
+
+https://github.com/TeamMidnightDust/MidnightLib

--- a/tags/lib/nbtcrafting.ytag
+++ b/tags/lib/nbtcrafting.ytag
@@ -1,7 +1,0 @@
-type: text
-
----
-
-NBT Crafting is a library that allows you to change or add cooking or crafting recipes to have nbt input and output
-
-https://github.com/Siphalor/nbt-crafting

--- a/tags/lib/owo.ytag
+++ b/tags/lib/owo.ytag
@@ -1,0 +1,7 @@
+type: text
+
+---
+
+oωo (owo-lib) is a generic library/GUI/config mod for Fabric.
+
+https://github.com/wisp-forest/owo-lib

--- a/tags/lib/paradoxconfig.ytag
+++ b/tags/lib/paradoxconfig.ytag
@@ -1,7 +1,0 @@
-type: text
-
----
-
-Paradox Config is a **kotlin based** configuration api for mods to use to store data.
-
-https://github.com/RedstoneParadox/paradox-config

--- a/tags/lib/patchouli.ytag
+++ b/tags/lib/patchouli.ytag
@@ -1,0 +1,7 @@
+type: text
+
+---
+
+Patchouli provides in-game, data-driven documentation of mod features.
+
+https://github.com/VazkiiMods/Patchouli/

--- a/tags/lib/polymer.ytag
+++ b/tags/lib/polymer.ytag
@@ -1,0 +1,7 @@
+type: text
+
+---
+
+Polymer is a library for creating server-side-only content mods.
+
+https://github.com/Patbox/polymer

--- a/tags/lib/yacl.ytag
+++ b/tags/lib/yacl.ytag
@@ -1,0 +1,7 @@
+type: text
+
+---
+
+YACL (YetAnotherConfigLib) is a configuration library.
+
+https://modrinth.com/mod/yacl

--- a/tags/link/linkie.ytag
+++ b/tags/link/linkie.ytag
@@ -2,4 +2,4 @@ type: text
 
 ---
 
-<https://linkie.shedaniel.me/mappings>
+<https://linkie.shedaniel.dev/mappings>

--- a/tags/link/mojang/eula.ytag
+++ b/tags/link/mojang/eula.ytag
@@ -3,3 +3,5 @@ type: text
 ---
 
 https://www.minecraft.net/en-us/eula
+
+See also: <https://www.minecraft.net/en-us/usage-guidelines>

--- a/tags/substitution/mcwiki.ytag
+++ b/tags/substitution/mcwiki.ytag
@@ -2,4 +2,4 @@ type: text
 
 ---
 
-https://minecraft.fandom.com/wiki/{{0}}
+https://minecraft.wiki/w/{{0}}


### PR DESCRIPTION
Additions:

- `!!ois`, on ObjectInputStream
- 6 new library tags

Fixes:

- Link fixes: Minecraft Wiki, Linkie, Kotlinx-Serialization-Minecraft, Client Commands API (FAPI)
- Fix client command code snippet
- Remove libraries not maintained since 2021
- Deprecate Cloth-Config
- Remove mentions to rule 8
- Clarify contactmods tag