### PR TITLE
Add FAPI 0.86+ incompatibility notice to OptiFine tag

### DIFF
--- a/tags/faq/optifine.ytag
+++ b/tags/faq/optifine.ytag
@@ -7,10 +7,12 @@ OptiFine doesn't support Fabric natively.
 If you are willing to try alternatives, please look at this list:
 <https://fabricmc.net/wiki/community:optifine_alternatives>
 
-If you need shaders but not OptiFine, Iris is the mod for you. Find more about it here:
+If you're using OptiFine for shaders, Iris is the mod for you. Find more about it here:
 <https://irisshaders.dev/download>
 
 If, however, you really *really* want OptiFine, please know first OptiFine can cause heavy incompatibilities that are, in some cases, not easy to fix.
 
 OptiFabric is a mod that allows OptiFine to run on Fabric but be aware that some mods will not bother to provide compatibility for it, so use it at your own risk:
 <https://www.curseforge.com/minecraft/mc-mods/optifabric>
+
+Note that currently (as of 26-09-2023) OptiFabric is incompatible with Fabric API versions newer than 0.85.0.


### PR DESCRIPTION
Ideally this would be temporary. 

I'm interested in what you have to say about this. Telling users this will mean that they may downgrade FAPI to 0.85.0 which is not ideal and can cause issues with other mods. OptiFine itself is going to cause issues with other mods anyway though. Perhaps that's something to include in this notice. Or perhaps this notice should be its own tag. 

I've found myself telling users to downgrade FAPI to 0.85.0 many times now. They're either using features that aren't available with Fabric alternatives, or need performance improvements that they cannot get with Sodium due to incompatible hardware. And they _usually_ know from the OptiFine tag that OptiFine is going to break many *many* mods and that they'll remove either OptiFine or the mods. 