### PR TITLE
launchers: List Prism Launcher before MultiMC

### DIFF
--- a/tags/faq/launchers.ytag
+++ b/tags/faq/launchers.ytag
@@ -17,8 +17,8 @@ embed:
       name: List of Some Alternative Launchers
       inline: false
       value: |
-        * [MultiMC](https://multimc.org/)
         * [Prism Launcher](https://prismlauncher.org/)
+        * [MultiMC](https://multimc.org/)
         * [GDLauncher](https://gdlauncher.com/)
         * [ATLauncher](https://atlauncher.com/)
         * [CurseForge App](https://download.curseforge.com/)


### PR DESCRIPTION
Prism Launcher is a more modern and updated fork of MultiMC with more features.