### PR TITLE
Remove MultiMC from launchers.ytag

### DIFF
--- a/tags/faq/launchers.ytag
+++ b/tags/faq/launchers.ytag
@@ -5,7 +5,7 @@ embed:
   title: Alternative Minecraft Launchers
   fields:
     -
-      name: Advantages of Using an Alternative Launcher
+      name: Advantages of using an Alternative Launcher
       inline: false
       value: |
         * Most alternative launchers have one-click installs for Fabric
@@ -17,7 +17,6 @@ embed:
       name: List of Some Alternative Launchers
       inline: false
       value: |
-        * [MultiMC](https://multimc.org/)
         * [Prism Launcher](https://prismlauncher.org/)
         * [GDLauncher](https://gdlauncher.com/)
         * [ATLauncher](https://atlauncher.com/)


### PR DESCRIPTION
Reasons: MultiMC isn't as up-to-date as PrismLauncher. On Linux PrismLauncher is also available on a wider variety of package managers.