### PR TITLE
Prevent link previews in `llm` tag

### DIFF
--- a/tags/faq/llm.ytag
+++ b/tags/faq/llm.ytag
@@ -2,7 +2,7 @@ type: text
 
 ---
 
-Whilst LLMs (Large Language Models) like [ChatGPT](https://chat.openai.com/) and [Gemini](https://gemini.google.com/) are impressive tools, **they are not recommended for first-time Fabric mod developers due to their inconsistency and potential for generating inaccurate code. **
+Whilst LLMs (Large Language Models) like [ChatGPT](<https://chat.openai.com/>) and [Gemini](<https://gemini.google.com/>) are impressive tools, **they are not recommended for first-time Fabric mod developers due to their inconsistency and potential for generating inaccurate code. **
 
 LLMs may generate incorrect code that:
 


### PR DESCRIPTION
`llm` tag shows the link preview for Gemini. This PR disables link preview for both links.