### PR TITLE
Shorten binarysearch tag and add link to tool

### DIFF
--- a/tags/guide/binarysearch.ytag
+++ b/tags/guide/binarysearch.ytag
@@ -2,10 +2,8 @@ type: text
 
 ---
 
-A binary search can be used to quickly find a specific mod causing trouble, which can be especially useful when logs don't give a conclusive answer to your issue.
+A binary search helps find a single mod causing trouble.
 
-Start by removing or disabling half of your mods, then test if the problem still occurs. If it does, remove half of the remaining mods and test again. If it doesn't, add back half of the mods you just removed.
+Remove or disable half of your mods. If the problem is gone, remove half of the rest and try again. If it's not, or it's a different problem, add back half of the mods you just removed.
 
-Keep in mind you don't have to stick strictly to halves each time, and may have to enable some library mods like Fabric API out of order.
-
-By repeating this on an increasingly smaller set of mods, you'll find the problematic mod within a few iterations.
+You don't have to do only halves each time, and may have to enable some dependency mods out of order.

--- a/tags/guide/binarysearch.ytag
+++ b/tags/guide/binarysearch.ytag
@@ -7,3 +7,5 @@ A binary search helps find a single mod causing trouble.
 Remove or disable half of your mods. If the problem is gone, remove half of the rest and try again. If it's not, or it's a different problem, add back half of the mods you just removed.
 
 You don't have to do only halves each time, and may have to enable some dependency mods out of order.
+
+There's also a [tool](<https://github.com/skycatminepokie/FabricBinarySearchTool>) made by the community for doing this automatically. Keep in mind that this is *not* developed by the Fabric team, so please use caution.

--- a/tags/guide/binarysearch.ytag
+++ b/tags/guide/binarysearch.ytag
@@ -4,7 +4,7 @@ type: text
 
 A binary search helps find a single mod causing trouble.
 
-Remove or disable half of your mods. If the problem is gone, remove half of the rest and try again. If it's not, or it's a different problem, add back half of the mods you just removed.
+Remove or disable half of your mods. If the problem is gone, remove half of the what's left and try again. If it's not, or it's a different problem, add back half of the mods you just removed.
 
 You don't have to do only halves each time, and may have to enable some dependency mods out of order.
 


### PR DESCRIPTION
The binarysearch tag is quite long, and can look daunting to people. I tried to shorten it a bit, and added a link to my [tool](https://github.com/skycatminepokie/FabricBinarySearchTool) for doing it automatically. I am perfectly fine if maintainers think that the tool shouldn't be on the tag, but I figured it's worth asking.