### PR TITLE
Create a tag describing the vanity URL scams

### DIFF
--- a/tags/faq/scam
+++ b/tags/faq/scam
@@ -1,0 +1,9 @@
+type: text
+
+---
+
+Scammers are targeting the Minecraft community with fake Fabric Discord servers. These people are **not** affiliated with Fabric! 
+
+They have several common tactics, including vandalizing servers, spam-posting in online games and livestreams, and posting threatening messages in Dynmap chats. They mostly target offline-mode servers.
+
+These scammers may ask you to log in or authenticate with your Microsoft account. **Don't do this!** They will steal your account. 


### PR DESCRIPTION
Describes a recent (as of 12/20/2024) scam involving multiple Discord vanity URLs created by scammers. Gives a high-level overview of their tactics, and advises users not to join their servers or reveal their Microsoft account information.