### PR TITLE
Remove Iris link in optifine tag

### DIFF
--- a/tags/faq/optifine.ytag
+++ b/tags/faq/optifine.ytag
@@ -7,9 +7,6 @@ OptiFine doesn't support Fabric natively.
 If you are willing to try alternatives, please look at this list:
 <https://fabricmc.net/wiki/community:optifine_alternatives>
 
-If you're using OptiFine for shaders, Iris is the mod for you. Find more about it here:
-<https://irisshaders.dev/download>
-
 If, however, you really *really* want OptiFine, please know first OptiFine can cause heavy incompatibilities that are, in some cases, not easy to fix.
 
 OptiFabric is a mod that allows OptiFine to run on Fabric but be aware that some mods will not bother to provide compatibility for it, so use it at your own risk:


### PR DESCRIPTION
It's redundant and makes it unnecessarily long