### PR TITLE
Add FTB App to launchers tag

### DIFF
--- a/tags/faq/launchers.ytag
+++ b/tags/faq/launchers.ytag
@@ -24,6 +24,7 @@ embed:
         * [CurseForge App](https://download.curseforge.com/)
         * [Modrinth App](https://modrinth.com/app)
         * [Technic Launcher](https://www.technicpack.net/) (Modpack only)
+        * [FTB App](https://www.feed-the-beast.com/ftb-app)
 
 ---
 


### PR DESCRIPTION
Tbh the launchers tag could do with a bit of a cleanup. MultiMC is the odd one out that doesn't support the same features like mod downloading and updating. If we lowered MultiMC in the list, we could rephrase the tag to just say "one-click installs for Fabric" instead of "Most alternative launchers have one-click installs for Fabric", for example. 