### PR TITLE
Add !!configlibraries and !!configlibs

### DIFF
--- a/tags/link/configlibraries.ytag
+++ b/tags/link/configlibraries.ytag
@@ -1,0 +1,5 @@
+type: text
+
+---
+
+https://kr1v.net/libs/

--- a/tags/link/configlibs.ytag
+++ b/tags/link/configlibs.ytag
@@ -1,0 +1,2 @@
+type: alias
+target: link/configlibraries


### PR DESCRIPTION
Add a tag linking my https://kr1v.net/libs. This is a filterable index/list of fabric config libraries, including versions, config formats supported, extra features, and more.

Source for the index: https://github.com/kr1viah/FabricConfigLibraryIndex