### PR TITLE
Update `logs` Tag Formatting, Fix `paste` Tag Links

### DIFF
--- a/tags/guide/logs.ytag
+++ b/tags/guide/logs.ytag
@@ -8,11 +8,11 @@ embed:
 
 For support with crashes or other errors, provide the relevant logs:
 
-Logs: Located in the `logs` folder in your game directory. The latest log is a text file called `latest` or `latest.log`.
-Crash reports: Located in the `crash-reports` folder in your game directory. If generated, share the newest one.
+**Logs**: Located in the `logs` folder in your game directory. The latest log is a text file called `latest` or `latest.log`.
+**Crash reports**: Located in the `crash-reports` folder in your game directory. If generated, share the newest one.
 
-To make it easier for others to read, do not copy-and-paste, screenshot, or significantly alter your logs. 
+To make it easier for others to read, **do not copy-and-paste, screenshot, or significantly alter your logs**. 
+
 Upload logs to a paste site and share the link so others do not have to download it. Type `!!paste` for a list of sites. 
 
-
-**»** [More information](https://docs.fabricmc.net/players/troubleshooting/uploading-logs)
+-# For more information see [Fabric Documentation: Uploading Logs](<https://docs.fabricmc.net/players/troubleshooting/uploading-logs>)

--- a/tags/guide/paste.ytag
+++ b/tags/guide/paste.ytag
@@ -11,9 +11,7 @@ This way, others don't have to download the file to read it, and it's easier to 
 
 **Paste sites and their size limits:**
 
-**»** [GitHub Gist](https://gist.github.com/): 100 MiB / Requires an account
-**»** [Paste.gg](https://paste.gg/): 15 MiB / Account is optional
-**»** [Mclo.gs](https://mclo.gs/): 10 MiB / Anonymous (designed specifically for Minecraft logs)
-**»** [Paste.ee](https://paste.ee/): 1 MiB / Account is optional (raises limit to 6 MiB)
-**»** [Pastebin.com](https://pastebin.com/): 512 KiB / Account is optional
-**»** [Hastebin.com](https://hastebin.com/): 400 KiB / Anonymous
+* [mclo.gs](<https://mclo.gs/>): 10 MiB / Anonymous (designed specifically for Minecraft logs)
+* [pastes.dev](<https://pastes.dev/>): 50 MiB / Anonymous
+* [Pastebin.com](<https://pastebin.com/>): 512 KiB / Account is optional
+* [GitHub Gist](<https://gist.github.com/>): 100 MiB / Requires an account


### PR DESCRIPTION
* Updated the `logs` tag to to highlight some important parts. Replaced the `»` with a subtext.
* Updated the `paste` tag with the commonly used paste sites
    * Removed `paste.gg` as it is offline 
    * Removed `hastebin` since it requires you to read a whole lot of T&C.
    * Removed `paste.ee` as it presents with a redirect notice.
    * Added `pastes.dev` as a new option.