### PR TITLE
Update Rule 8

### DIFF
--- a/tags/faq/rule8.ytag
+++ b/tags/faq/rule8.ytag
@@ -1,8 +1,14 @@
-type: text
+type: embed
 
+colour: fabric
+embed:
+    title: Rule 8
 ---
 
-> :eight: Do not mention names from MCP, Mojang or other proprietary mappings to influence Yarn development or in <#521545796882006027>
+> 8️⃣  Do not upload jar and other executable files, as well as archives containing them
 
-This is due to them having a more restrictive license than yarn. We don't want yarn contributors to pick up names from other mappings due to their licensing. 
-You may, however, mention them to the extent to which they are present in the game jar. This includes constants and some unobfuscated name (such as parts of blaze3d). Meaning that if a name can be deducted from the code it is not necessarily part of the mappings. 
+Do not upload .jar, .exe, Gradle scripts, or archives containing them directly to the server. Minecraft mods execute code on your machine and are a frequent vector for malware and account theft.
+
+- Upload your source code to GitHub or a similar repository.
+- Never download compiled mods from Discord, even from friends.
+- Contact moderators immediately if anyone from this server DMs you to test a mod or modpack.

--- a/tags/faq/rule8.ytag
+++ b/tags/faq/rule8.ytag
@@ -7,7 +7,7 @@ embed:
 
 > 8️⃣  Do not upload jar and other executable files, as well as archives containing them
 
-Do not upload `.jar`, `.exe`, `.sh`, Gradle scripts, or any other executable files (or archives containing them)directly to the server. Minecraft mods execute code on your machine and are a frequent vector for malware and account theft.
+Do not upload `.jar`, `.exe`, Gradle scripts, or any other executable files (or archives containing them) directly to the server. Minecraft mods execute code on your machine and are a frequent vector for malware and account theft.
 
 - Upload your source code to GitHub or a similar repository.
 - Never download compiled mods from Discord, even from friends.

--- a/tags/faq/rule8.ytag
+++ b/tags/faq/rule8.ytag
@@ -7,7 +7,7 @@ embed:
 
 > 8️⃣  Do not upload jar and other executable files, as well as archives containing them
 
-Do not upload .jar, .exe, Gradle scripts, or archives containing them directly to the server. Minecraft mods execute code on your machine and are a frequent vector for malware and account theft.
+Do not upload `.jar`, `.exe`, `.sh`, Gradle scripts, or any other executable files (or archives containing them)directly to the server. Minecraft mods execute code on your machine and are a frequent vector for malware and account theft.
 
 - Upload your source code to GitHub or a similar repository.
 - Never download compiled mods from Discord, even from friends.


### PR DESCRIPTION
Rule 8 was recently changed to:
> 8️⃣  Do not upload jar and other executable files, as well as archives containing them

I've updated the tag to match this change. I included 3 points that loosely elaborates on this rule based on the recent moderator messages.